### PR TITLE
Problem: building complex projects with dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -261,6 +261,30 @@
 		'';
 	};
 
+        alire = adaenv.mkDerivation rec {
+          name = "alire";
+          # v1.0.0 failed to fetch submodules, so using current HEAD
+          version = "1.1.0-dev+0f603c29";
+          src = fetchFromGitHub {
+            owner = "alire-project";
+            repo = "alire";
+            rev = "c63615df9bed6212881f61d769ab189b3f425a8b";
+            sha256 = "sha256-bs1myX6Qgsdp/RU9FvOaDJ6nB9gsa0oDsNjwYctP/Dw=";
+            fetchSubmodules = true;
+          };
+
+          buildInputs = [ gprbuild git ];
+
+          buildPhase = ''
+            gprbuild -j0 -P alr_env
+          '';
+
+          installPhase = ''
+            install -D bin/alr $out/bin/alr
+          '';
+
+        };
+
 	in 
 
 	# HERE BEGINS THE THINGS THAT THIS FLAKE PROVIDES:
@@ -270,6 +294,7 @@
 		gpr = gprbuild;
 		gnat = adaenv.cc;
 		spark = spark2014;
+                alr = alire;
 
 		# Notes on nix shell and nix develop:
 		# "nix develop" will open a shell environment that simulates the build environment
@@ -291,6 +316,7 @@
 				self.gpr
 				self.spark
 				self.asis
+                                self.alr
 			];
 		};
 


### PR DESCRIPTION
Building complex projects in Ada requires a lot of routine work to
bring in and set up dependencies.

Solution: use Alire (alr) to solve the problem

This change adds Alire to the flake.